### PR TITLE
Use the findstr build in command

### DIFF
--- a/src/dictatorship.js
+++ b/src/dictatorship.js
@@ -30,7 +30,7 @@ module.exports = {
             command = 'lsof -i tcp:' + port + ' | grep node | grep -i listen';
             rpid = / \d+ /gm;
         }else{
-            command = 'netstat -n -a -o | grep -i listening | grep :' + port;
+            command = 'netstat -n -a -o | findstr -i listening | findstr :' + port;
             rpid = /\d+$/gm;
         }
 


### PR DESCRIPTION
On my windows machine, grep is not a built in command. But "findstr" is one of these.

I just propose to use that for windows users.

Fix: #2 

Have a nice day,
Jehon