### PR TITLE
Fix killing process in windows, and filter pid to keep unique one's

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.log
+node_modules

--- a/README.md
+++ b/README.md
@@ -21,3 +21,12 @@ Look for processes currently listening in the provided port, `process.kill` all 
 ```
 
 **Not recommended for production environments.** The purpose of this module is to overthrow renegade node processes spawned by [grunt-contrib-watch](https://github.com/gruntjs/grunt-contrib-watch "grunt-contrib-watch on GitHub") and their ilk.
+
+## Test it ##
+To see it in actions, try in two different windows:
+
+```js
+npm start
+```
+
+None of them will hae a "EADDRINUSE", but only one will survive.

--- a/bin/server.js
+++ b/bin/server.js
@@ -1,0 +1,19 @@
+
+let dictatorship = require('../src/dictatorship');
+let express = require('express');
+let fs = require('fs');
+
+const port = 3568;
+
+dictatorship.overthrow(port, () => {
+	let app = express();
+
+	// Treat "/" to index.html
+	app.get('/', function (req, res) {
+	 	res.sendFile(__dirname + '/server.js');
+	});
+
+	let server = app.listen(port, function () {
+		console.log(`[server] Listening on port ${port}!`)
+	});
+});

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "url": "https://github.com/bevacqua/dictatorship/issues"
   },
   "devDependencies": {
-    "concurrently": "^3.5.0",
     "express": "^4.15.4"
   },
   "main": "./src/dictatorship.js",
@@ -25,7 +24,6 @@
     "npm": "1.2.x"
   },
   "scripts": {
-    "start": "node bin/server.js",
-    "test": "concurrent \"npm start\" \"npm start\""
+    "start": "node bin/server.js"
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,11 +15,17 @@
   "bugs": {
     "url": "https://github.com/bevacqua/dictatorship/issues"
   },
-  "dependencies": {
+  "devDependencies": {
+    "concurrently": "^3.5.0",
+    "express": "^4.15.4"
   },
   "main": "./src/dictatorship.js",
   "engines": {
     "node": "0.10.6",
     "npm": "1.2.x"
+  },
+  "scripts": {
+    "start": "node bin/server.js",
+    "test": "concurrent \"npm start\" \"npm start\""
   }
 }

--- a/src/dictatorship.js
+++ b/src/dictatorship.js
@@ -12,7 +12,12 @@ function execute(command, rpid, done){
             return done(); // err: no pids
         }
 
-        data.match(rpid).map(returnInt).forEach(function(pid){
+        data.match(rpid).map(returnInt)
+        // Set the PID list unique (thanks to https://stackoverflow.com/a/31158960/1954789)
+        .sort().filter(function(value, index, array) {
+            return (index === 0) || (value !== array[index-1]);
+        })
+        .forEach(function(pid){
             process.stdout.write('overthrowing pid ' + pid + '...');
             process.kill(pid);
             console.log('done');

--- a/src/dictatorship.js
+++ b/src/dictatorship.js
@@ -30,7 +30,7 @@ module.exports = {
             command = 'lsof -i tcp:' + port + ' | grep node | grep -i listen';
             rpid = / \d+ /gm;
         }else{
-            command = 'netstat -n -a -o | grep -i listening | grep :' + port;
+            command = 'netstat -n -a -o | findstr -i listening | findstr :' + port;
             rpid = /\d+$/gm;
         }
 


### PR DESCRIPTION
Hello,

Here is a double fix !
- Fix #3 and #2 : using native "findstr" command (instead of grep)
- Fix #1 : PID is filtered to be unique before killing processes

Enjoy,
Jean